### PR TITLE
Fix incorrect http client type

### DIFF
--- a/async_http_request.nim
+++ b/async_http_request.nim
@@ -113,11 +113,11 @@ elif not defined(js):
                               ctx: pointer, sslContext: SSLContext) {.gcsafe.}=
             try:
                 when defined(ssl):
-                    var client = newAsyncHttpClient(sslContext = sslContext)
+                    var client = newHttpClient(sslContext = sslContext)
                 else:
                     if url.parseUri.scheme == "https":
                         raise newException(AsyncHttpRequestError, "SSL support is not available. Compile with -d:ssl to enable.")
-                    var client = newAsyncHttpClient()
+                    var client = newHttpClient()
 
                 client.headers = newHttpHeaders(headers)
                 client.headers["Content-Length"] = $body.len

--- a/async_http_request.nimble
+++ b/async_http_request.nimble
@@ -1,5 +1,5 @@
 # Package
-version       = "0.1.1"
+version       = "0.1.2"
 author        = "Yuriy Glukhov"
 description   = "Basic http_request implementation for JS and native targets"
 license       = "MIT"


### PR DESCRIPTION
Previous PR contained a subtle error, whic resulted from copy paste. This commit reverts the original correct client type.