### PR TITLE
Don't call handler if error occurred

### DIFF
--- a/async_http_request.nim
+++ b/async_http_request.nim
@@ -89,13 +89,12 @@ elif not defined(js):
                 r = await cl.request(url, meth, body)
                 rBody = await r.body
                 cl.close()
+                handler((statusCode: parseStatusCode(r.status), status: r.status, body: rBody))
             except Exception as e:
                 if onError != nil:
                     onError(e)
                 else:
                     raise e
-            
-            handler((statusCode: parseStatusCode(r.status), status: r.status, body: rBody))
 
         proc doSendRequest(meth, url, body: string, headers: openarray[(string, string)],
                            sslContext: SSLContext,

--- a/async_http_request.nimble
+++ b/async_http_request.nimble
@@ -1,5 +1,5 @@
 # Package
-version       = "0.1.3"
+version       = "0.1.4"
 author        = "Yuriy Glukhov"
 description   = "Basic http_request implementation for JS and native targets"
 license       = "MIT"


### PR DESCRIPTION
Before this change if `onError` was set, `handler` was called after `onError` causing segmentation fault.